### PR TITLE
AmountAsString will take into account minor unit of the currency;

### DIFF
--- a/convert/conversion_test.go
+++ b/convert/conversion_test.go
@@ -65,9 +65,27 @@ func TestConvertTo(t *testing.T) {
 			name: "eur_to_vnd",
 			args: args{
 				obj:  money.MustForge(100, "EUR"),
-				rate: ForgeRate(money.MustGetCurrencyByISOCode("EUR"), money.MustGetCurrencyByISOCode("VND"),  25258.410459),
+				rate: ForgeRate(money.MustGetCurrencyByISOCode("EUR"), money.MustGetCurrencyByISOCode("VND"), 25258.410459),
 			},
 			wantRes: money.MustForge(25258, "VND"),
+			wantErr: false,
+		},
+		{
+			name: "eur_to_tnd",
+			args: args{
+				obj:  money.MustForge(100, "EUR"),
+				rate: ForgeRate(money.MustGetCurrencyByISOCode("EUR"), money.MustGetCurrencyByISOCode("TND"), 3.148775),
+			},
+			wantRes: money.MustForge(3149, "TND"),
+			wantErr: false,
+		},
+		{
+			name: "tnd_to_eur",
+			args: args{
+				obj:  money.MustForge(3149, "TND"),
+				rate: ForgeRate(money.MustGetCurrencyByISOCode("EUR"), money.MustGetCurrencyByISOCode("TND"), 3.148775),
+			},
+			wantRes: money.MustForge(100, "EUR"),
 			wantErr: false,
 		},
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -2,6 +2,7 @@ package money
 
 import (
 	"encoding/json"
+	"errors"
 )
 
 func (m *Money) MarshalJSON() ([]byte, error) {
@@ -15,6 +16,11 @@ func (m *Money) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &dto); err != nil {
 		return err
 	}
+
+	if dto.Currency == "" {
+		return errors.New("invalid money object: empty currency")
+	}
+
 	var err error
 	*m, err = dto.ExtractMoney()
 

--- a/money.go
+++ b/money.go
@@ -33,7 +33,7 @@ func (m Money) Float() float64 {
 }
 
 func (m Money) AmountAsString() string {
-	return fmt.Sprintf("%.2f", m.Float())
+	return fmt.Sprintf("%."+strconv.Itoa(m.Currency.MinorUnit)+"f", m.Float())
 }
 
 // Forge

--- a/money_test.go
+++ b/money_test.go
@@ -37,6 +37,26 @@ func TestOutputASFloat(t *testing.T) {
 	assert.Equal(t, OneEur.Float(), float64(1))
 }
 
+func TestOutputASFloatZeroDecimals(t *testing.T) {
+	amount, err := money.Forge(1011, "VND")
+	assert.Nil(t, err)
+	assert.Equal(t, float64(1011), amount.Float())
+
+	OneVND, err := money.Forge(1000, "VND")
+	assert.Nil(t, err)
+	assert.Equal(t, float64(1000), OneVND.Float())
+}
+
+func TestOutputASFloatThreeDecimals(t *testing.T) {
+	amount, err := money.Forge(1011, "JOD")
+	assert.Nil(t, err)
+	assert.Equal(t, float64(1.011), amount.Float())
+
+	OneJOD, err := money.Forge(1000, "JOD")
+	assert.Nil(t, err)
+	assert.Equal(t, float64(1.000), OneJOD.Float())
+}
+
 func TestFloat(t *testing.T) {
 	OneEurAndOneCent := money.FloatEUR(1.01)
 
@@ -49,6 +69,26 @@ func TestAmountAsString(t *testing.T) {
 
 	assert.Equal(t, OneEurAndOneCent.Int64(), int64(101))
 	assert.Equal(t, OneEurAndOneCent.AmountAsString(), "1.01")
+}
+
+func TestOutputAsStringZeroDecimals(t *testing.T) {
+	amount, err := money.Forge(1011, "VND")
+	assert.Nil(t, err)
+	assert.Equal(t, "1011", amount.AmountAsString())
+
+	OneVND, err := money.Forge(1000, "VND")
+	assert.Nil(t, err)
+	assert.Equal(t, "1000", OneVND.AmountAsString())
+}
+
+func TestOutputAStringThreeDecimals(t *testing.T) {
+	amount, err := money.Forge(1011, "JOD")
+	assert.Nil(t, err)
+	assert.Equal(t, "1.011", amount.AmountAsString())
+
+	OneJOD, err := money.Forge(1000, "JOD")
+	assert.Nil(t, err)
+	assert.Equal(t, "1.000", OneJOD.AmountAsString())
 }
 
 func TestMoney_IsEquals(t *testing.T) {


### PR DESCRIPTION
better unmarshaling error;
tests for non-100 based currency conversion