### PR TITLE
Added PercentOffFloat method for floating point percentages

### DIFF
--- a/money.go
+++ b/money.go
@@ -117,7 +117,11 @@ func (m Money) IsEquals(cmp Money) bool {
 }
 
 func (m Money) PercentOff(perc int) Money {
-	div := float64(perc) / 100
+	return m.PercentOffFloat(float64(perc))
+}
+
+func (m Money) PercentOffFloat(perc float64) Money {
+	div := perc / 100
 	return ForgeFloatWithCurrency(m.Float()*div, m.Currency)
 }
 

--- a/money_test.go
+++ b/money_test.go
@@ -110,6 +110,17 @@ func TestMoney_PercentageOff(t *testing.T) {
 	assert.True(t, OneEurAndOneCent.IsEquals(money.EUR(10009)))
 }
 
+func TestMoney_PercentageOffFloat(t *testing.T) {
+	amount := money.FloatEUR(100.09)
+
+	pOff := amount.PercentOffFloat(20.5)
+
+	assert.Equal(t, pOff.Int64(), int64(2052))
+	assert.Equal(t, pOff.Float(), 20.52)
+
+	assert.True(t, amount.IsEquals(money.EUR(10009)))
+}
+
 func TestMoney_CentsValue(t *testing.T) {
 	type fields struct {
 		Amount      int64


### PR DESCRIPTION
Added new method that also works for non integer percentages.
Considering the old method for integers works the same with a cast to float, also moved that to fall back on this new method, with a cast to float.