### PR TITLE
use struct receiver for `MarshalJSON`

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 )
 
-func (m *Money) MarshalJSON() ([]byte, error) {
+func (m Money) MarshalJSON() ([]byte, error) {
 	dto := m.ExtractDTO()
 
 	return json.Marshal(dto)


### PR DESCRIPTION
This is technically a breaking change, but I don't know if the current behavior is expected. When putting a `Money` into a struct as a non-pointer, `json.Marshal` doesn't respect the `(*Money).MarshalJSON`. One must either embed a Money-pointer, marshal a pointer to a type that embed or implement a MarshalJSON for the custom struct to make it work:

```go
package main

import (
	"encoding/json"
	"log"

	"github.com/radical-app/money"
)

type Product struct {
	Price money.Money `json:"price"`
}

func main() {
	b, _ := json.Marshal(Product{Price: money.USD(100)})
	log.Println(string(b))

        // Expected output: {"price":{"amount":100,"currency":"USD","symbol":"$","cents":100}}
        // Actual output: {"price":{"amount":100,"currency":{"currency":"USD","unit":2,"symbol":"$","ShowCodeNextToSymbol":false}}}

        // This works too:
        b, _ := json.Marshal(&Product{Price: money.USD(100)})
        
        // Output: {"price":{"amount":100,"currency":"USD","symbol":"$","cents":100}}
}
```

Making `MarshalJSON` take a struct-receiver should make it work correctly, but if someone depends on the current behavior, then that would be a breaking change, so I'm not sure if you even want this change (feel free to close).
